### PR TITLE
FP-10610: Parse `al1` and `zal` segments

### DIFF
--- a/lib/segments/zal.json
+++ b/lib/segments/zal.json
@@ -1,0 +1,12 @@
+{
+  "name": "ZAL",
+  "fields": [
+    "Description",
+    "Timestamp",
+    "3",
+    "4",
+    "Type",
+    "Status",
+    "Allergy Details"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodehl7",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Forked from Loksly/nodehl7 - NodeJS Library for parsing HL7 Messages",
   "main": "lib/hl7.js",
   "scripts": {


### PR DESCRIPTION
#### :link: Board reference:

* [Parse Allergy information from AL1 and ZAL segments  | ADT](https://myfertility.atlassian.net/browse/FP-10610)

---

#### 📓 Description:

When creating and updating patients from an ADT^A04, ADT^A05 or ADT^A08, parse and save the Allergy Information from these fields:
- AL1-3.2 - Allergen
- ZAL-7.2 - Reaction

---

#### 💻 Tech/Approach Description:

Add `ZAL` segment definition.

